### PR TITLE
Convert base to use puppet-librarian itself too to pull in nubis-puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 packer/variables.json
 nubis-puppet.tar.gz
 nubis-puppet
+Puppetfile.lock
+.tmp
+.librarian

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,7 @@ release: release-increment nubis-puppet packer
 force: ;
 
 nubis-puppet: force
-	@[ -d $@ ] && cd $@ && git pull || \
-	git clone git@github.com:mozilla/$@.git
-	cd $@ && librarian-puppet install
-	rm -f nubis-puppet.tar.gz
+	librarian-puppet install --path=nubis-puppet
 	tar --exclude='nubis-puppet/.*' -zpcvf nubis-puppet.tar.gz nubis-puppet
 
 release-increment:

--- a/Puppetfile
+++ b/Puppetfile
@@ -3,25 +3,9 @@
 
 forge "https://forgeapi.puppetlabs.com"
 
-# use dependencies defined in metadata.json
-#metadata
-
-# use dependencies defined in Modulefile
-# modulefile
-
-# A module from the Puppet Forge
-# mod 'puppetlabs-stdlib'
-
-# A module from git
-# mod 'puppetlabs-ntp',
-#   :git => 'git://github.com/puppetlabs/puppetlabs-ntp.git'
-
-# A module from a git branch/tag
-# mod 'puppetlabs-apt',
-#   :git => 'https://github.com/puppetlabs/puppetlabs-apt.git',
-#   :ref => '1.4.x'
-#
-
+# All we should ever need
 mod 'nubis-puppet',
    :git => "http://github.com/mozilla/nubis-puppet.git",
    :ref => "master"
+
+# Eventually, need to pin at a revision

--- a/packer/main.json
+++ b/packer/main.json
@@ -37,9 +37,9 @@
   },
   {
     "type": "puppet-masterless",
-    "manifest_dir": "nubis-puppet/manifests",
-    "manifest_file": "nubis-puppet/manifests/init.pp",
-    "module_paths": ["nubis-puppet/modules"]
+    "manifest_dir": "nubis-puppet/puppet/manifests",
+    "manifest_file": "nubis-puppet/puppet/manifests/init.pp",
+    "module_paths": ["nubis-puppet"]
   }
   ]
 }

--- a/packer/release.json
+++ b/packer/release.json
@@ -1,4 +1,4 @@
 {
   "release": "0",
-  "build": "50"
+  "build": "55"
 }


### PR DESCRIPTION
Removes some extra code, and eventually will let us easliy pin at given
nubis-puppet releases