### PR TITLE
Add consul auto-discovery in packer template. Needs to move into puppet eventually

### DIFF
--- a/packer/consul-autojoin.sh
+++ b/packer/consul-autojoin.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# This is an auto-joiner for consul
+
+eval `ec2metadata --user-data`
+
+cat <<EOF | tee /etc/consul/zzz-startup.json
+{
+  "encrypt": "$CONSUL_SECRET",
+  "datacenter": "$CONSUL_DC"
+}
+EOF
+
+#XXX: Wish there was a way to self-discover members of our autoscaling group...
+if [ "$CONSUL_JOIN" ]; then
+cat <<EOF | tee /etc/consul/zzz-join.json
+{
+  "start_join": [ "$CONSUL_JOIN" ]
+}
+EOF
+fi
+
+if [ "$CONSUL_PUBLIC" -eq "1" ]; then
+PUBLIC_IP=`ec2metadata --public-ipv4`
+
+cat <<EOF | tee /etc/consul/zzz-public.json
+{
+  "advertise_addr": "$PUBLIC_IP"
+}
+EOF
+fi
+
+service consul restart
+
+exit 0

--- a/packer/main.json
+++ b/packer/main.json
@@ -40,6 +40,18 @@
     "manifest_dir": "nubis-puppet/manifests",
     "manifest_file": "nubis-puppet/manifests/init.pp",
     "module_paths": ["nubis-puppet/modules"]
+  },
+  {
+      "type": "file",
+      "source": "packer/consul-autojoin.sh",
+      "destination": "/tmp/autojoin.sh"
+  },
+  {
+      "type": "shell",
+      "inline" : [
+        "sudo mv /tmp/autojoin.sh /etc/rc.local",
+        "sudo chmod +x /etc/rc.local"
+      ]
   }
   ]
 }


### PR DESCRIPTION
Using user-data in instances to pass-in info:

CONSUL_SECRET=""
CONSUL_DC="us-west-1"
CONSUL_JOIN="some.host.name.to.bootstrap.with"