### PR TITLE
Include DNSMasq in the base image

### DIFF
--- a/nubis/packer/release.json
+++ b/nubis/packer/release.json
@@ -1,4 +1,4 @@
 {
   "release": "0",
-  "build": "84"
+  "build": "91"
 }

--- a/nubis/puppet/dnsmasq.pp
+++ b/nubis/puppet/dnsmasq.pp
@@ -1,0 +1,8 @@
+class { 'dnsmasq':
+
+}
+
+dnsmasq::dnsserver { 'consul':
+  domain => "consul",
+  ip => "127.0.0.1#8600",
+}

--- a/nubis/puppet/init.pp
+++ b/nubis/puppet/init.pp
@@ -1,4 +1,5 @@
 import "confd.pp"
 import "consul.pp"
+import "dnsmasq.pp"
 import "fluentd.pp"
 import "postfix.pp"

--- a/nubis/terraform/inputs.tf
+++ b/nubis/terraform/inputs.tf
@@ -18,7 +18,7 @@ variable "region" {
 }
 
 variable "release" {
-  default = "0.84"
+  default = "0.91"
   description = "Release number of the architecture"
 }
 


### PR DESCRIPTION
configured to forward DNS queries to Amazon's resolvers,
but intercept lookups for .consul and forward it to the
locally running consul agent.